### PR TITLE
Editorial: fix typos in  7.1. Symmetric encryption

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -167,7 +167,7 @@ Two recommended padding schemes are PKCS#7 standardized in [[RFC5652]] and Bit p
 
 Note: Symmetric encryption alone provides just confidentiality, but does not provide data authenticity or integrity. Indeed, an attacker may intercept and modify the ciphertext without detection, potentially influencing the decrypted result. Therefore, the use of symmetric encryption algorithms only, with no authentication mechanism, is generally discouraged and it is preferable to use cryptographic mechanisms specifically designed to provide also authenticity and integrity.
 
-To provide confidentiality with authenticity it is reccommended to use a combination of symmetric encryption (providing confidentiality) with MACs (providiina authenticity and integrity). 
+To provide confidentiality with authenticity it is recommended to use a combination of symmetric encryption (providing confidentiality) with MACs (providing authenticity and integrity). 
 The usage of AES-CTR and HMAC (Encrypt-then-MAC) is recommended, or the usage of a single authenticated encryption with associated data (AEAD) scheme such as AES-GCM.
 
 ### Authenticated encryption ### {#authenticated-encryption}


### PR DESCRIPTION
Fix editorial typos in the symmetric encryption guidance:

- reccommended → recommended
- providiina → providing

This does not change the technical recommendation.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Dahkenangnon/security-guidelines-cryptography/pull/21.html" title="Last updated on Jun 10, 2026, 1:07 PM UTC (ff4f1b6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/security-guidelines-cryptography/21/a25a806...Dahkenangnon:ff4f1b6.html" title="Last updated on Jun 10, 2026, 1:07 PM UTC (ff4f1b6)">Diff</a>